### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
-
 env:
   UV_FROZEN: 1
 
@@ -26,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - uses: pre-commit/action@v3.0.1
         env:
@@ -60,7 +58,7 @@ jobs:
         run: uv python pin "${{ matrix.python-version }}"
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync --frozen
 
       - name: Build package
         run: uv build

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ help: Makefile  ## Show help
 # =============================================================================
 install:  ## Install deps
 	uv python install
-	uv sync --frozen --all-extras
+	uv sync --frozen
 	pre-commit install --install-hooks
 .PHONY: install
 
 update:  ## Update deps and tools
-	uv sync --upgrade --all-extras
+	uv sync --upgrade
 	pre-commit autoupdate
 .PHONY: update
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,17 +7,9 @@ license = "MIT"
 requires-python = ">=3.9, <4.0"
 dependencies = ["pydantic>=2,<3"]
 
-[project.optional-dependencies]
-dev = [
-	"mypy~=1.11",
-	"ruff~=0.6",
-]
-test = [
-	"coverage~=7.3",
-	"pytest-cov>=5,<7",
-	"pytest-sugar~=1.0",
-	"pytest~=8.0",
-]
+[dependency-groups]
+dev = ["mypy~=1.11", "ruff~=0.6"]
+test = ["coverage~=7.3", "pytest-cov>=5,<7", "pytest-sugar~=1.0", "pytest~=8.0"]
 
 [project.urls]
 Homepage = "https://github.com/lasuillard/pydantic-fixedwidth"
@@ -27,6 +19,9 @@ Issues = "https://github.com/lasuillard/pydantic-fixedwidth/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["pydantic_fixedwidth"]
@@ -69,7 +64,7 @@ addopts = [
 	"--cov-report=xml",
 	"--show-capture=no",
 	"--junitxml=junit.xml",
-	"-rs"
+	"-rs",
 ]
 testpaths = ["tests"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "ruff" },
@@ -343,16 +343,19 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "coverage", marker = "extra == 'test'", specifier = "~=7.3" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.11" },
-    { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "~=8.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5,<7" },
-    { name = "pytest-sugar", marker = "extra == 'test'", specifier = "~=1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.6" },
+requires-dist = [{ name = "pydantic", specifier = ">=2,<3" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = "~=1.11" },
+    { name = "ruff", specifier = "~=0.6" },
 ]
-provides-extras = ["dev", "test"]
+test = [
+    { name = "coverage", specifier = "~=7.3" },
+    { name = "pytest", specifier = "~=8.0" },
+    { name = "pytest-cov", specifier = ">=5,<7" },
+    { name = "pytest-sugar", specifier = "~=1.0" },
+]
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.